### PR TITLE
Update payment-method.html.twig

### DIFF
--- a/src/Resources/views/storefront/component/payment/payment-method.html.twig
+++ b/src/Resources/views/storefront/component/payment/payment-method.html.twig
@@ -9,7 +9,7 @@
            {% if page.isPaymentChangeable is defined and not page.isPaymentChangeable %}
               disabled="disabled"
            {% endif %}
-           class="{{ formCheckInputClass }} payment-method-input {% if 'handler_adyen_' in payment.formattedHandlerIdentifier %}adyen-payment-method-input-radio{% endif %}">
+           class="{{ formCheckInputClass ?? 'form-check-input' }} payment-method-input {% if 'handler_adyen_' in payment.formattedHandlerIdentifier %}adyen-payment-method-input-radio{% endif %}">
 {% endblock %}
 
 {% block component_payment_method_description %}


### PR DESCRIPTION
Currently installed: v6.5.3.0 

Problem: variable `formCheckInputClass` is removed since 6.5. 

Solution: Use Bootstrap 5 class (Shopware 6.5+) when formCheckInputClass is not defined so we stay compatible with 6.4 and 6.5.